### PR TITLE
Support custom module file template

### DIFF
--- a/conda-env-mod
+++ b/conda-env-mod
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Amiya K Maji and Lev Gorenstein
-# Copyright: Purdue University, 2019.
+# Copyright: Purdue University, 2023.
 #
 # This script assumes that you have Lmod and Anaconda installed on your system.
 # You should not set $PYTHONPATH to base Anaconda installation.

--- a/conda-env-mod
+++ b/conda-env-mod
@@ -22,6 +22,12 @@ MODULE_INIT_SCRIPT="/etc/profile.d/modules.sh"
 					# Script to initialize Lmod commands.
 BASE_CONDA_MODULE_NAME="anaconda"	# This is what you call the base
 					# anaconda module.
+DEFAULT_TEMPLATE_DIR="templates/rcac"   #
+                                        #
+SCRIPT_TOP_DIR="$(realpath ${BASH_SOURCE[0]} | xargs dirname)"
+                                        #
+DEFAULT_MODULE_TEMPLATE="${SCRIPT_TOP_DIR}/${DEFAULT_TEMPLATE_DIR}/modules/${ENVIRONMENT_MODULE_TYPE}/default.sh"
+                                        #
 # end configurations                    #
 #########################################
 
@@ -255,60 +261,16 @@ function create_module()
 		mkdir -p "${MODULE_DIR}"
 	fi
 
+	if [ ! -f "${MODULE_TEMPLATE}" ]; then
+		echo "Cannot locate module template: ${MODULE_TEMPLATE}"
+		echo "Aborting module file generation."
+		exit 1
+	fi
+
 	MODULE_FILE="${MODULE_DIR}/${ENV_NAME}-py${PY}.lua"
 	CONDA_MODULE=$(module --redirect --terse list ${BASE_CONDA_MODULE_NAME} | grep "^${BASE_CONDA_MODULE_NAME}\/.*")
 
-	cat <<-EOF > "${MODULE_FILE}"
-		-- created on $(date) by $USER
-
-	EOF
-	if [ "${CONDA_MODULE}" != "" ]; then
-		cat <<-EOF >> "${MODULE_FILE}"
-			depends_on("${CONDA_MODULE}")
-
-		EOF
-	elif [ -f "${CONDA_PREFIX}/bin/conda" ]; then
-		cat <<-EOF >> "${MODULE_FILE}"
-			-- Use the base conda that created this environment.
-			prepend_path("PATH","${CONDA_PREFIX}/bin")
-		EOF
-	else
-		echo -e "WARNING: Couldn't find an anaconda module.\nPlease make sure you to initialize conda separately."
-	fi
-	cat <<-EOF >> "${MODULE_FILE}"
-		local modroot = "${ENV_DIR}"
-		local pyver   = "${PY}"
-
-		local bashStr = 'eval '..modroot..'/bin/pip "\$@"'
-		local cshStr  = "eval "..modroot.."/bin/pip \$*"
-		set_shell_function("pip",bashStr,cshStr)
-		-- If this is Python3 environment, brace against 'pip3', too
-		if (string.match(pyver,"^3%.")) then
-		 	set_shell_function("pip3",bashStr,cshStr)
-		end
-
-		pushenv("CONDA_PREFIX",modroot)
-		pushenv("CONDA_DEFAULT_ENV",modroot)
-		prepend_path("LD_LIBRARY_PATH",modroot.."/lib")
-		prepend_path("PYTHONPATH",modroot.."/lib/python${PY_S}/site-packages")
-		pushenv("PYTHONNOUSERSITE","1")
-	EOF
-	echo >> "${MODULE_FILE}"
-
-	if [[ $Opt_LOCAL_PY -eq 0 ]]; then
-		# if user put down base-python, then use Python from base Anaconda
-		cat <<-EOF >> "${MODULE_FILE}"
-			-- This line is deliberately commented out.
-			-- We want to use Python from base Anaconda.
-			-- prepend_path("PATH",modroot.."/bin")
-		EOF
-	else
-		# python from the environment (python -V) is added to PYTHONPATH by default
-		cat <<-EOF >> "${MODULE_FILE}"
-			-- Using Python and tools from the environment
-			prepend_path("PATH",modroot.."/bin")
-		EOF
-	fi
+	source ${MODULE_TEMPLATE} > ${MODULE_FILE}
 
 	# And concoct instructions for the user.
 	# 'module use' is preferred, but fall back to 'use.own' if available
@@ -531,6 +493,7 @@ fi
 # Set initial values for flags
 MODULE_TOP="${MODULE_TOP_DEF}"
 MODULE_APP="${MODULE_APP_DEF}"
+MODULE_TEMPLATE="${DEFAULT_MODULE_TEMPLATE}"
 CONDA_ARGS=()
 CONDA_XTRA=() 		# CONDA_ARGS are used for -p/-n/-y, XTRA is for packages
 Opt_YES=0

--- a/conda-env-mod
+++ b/conda-env-mod
@@ -17,7 +17,7 @@ MODULE_TOP_DEF="$HOME/privatemodules" 	# Private modules reside here
 MODULE_APP_DEF="conda-env" 		# Our generated modules go here
 					# (a subdir in MODULE_TOP)
 ENVIRONMENT_MODULE_TYPE="lmod"          # At present only Lmod is supported
-					# May be extended to "tcl" later.
+					# TCL support is rudimentary.
 MODULE_INIT_SCRIPT="/etc/profile.d/modules.sh"
 					# Script to initialize Lmod commands.
 BASE_CONDA_MODULE_NAME="anaconda"	# This is what you call the base
@@ -223,7 +223,11 @@ function delete_env()
 	fi
 
 	# Delete the modulefile
-	MODULE_FILE="${MODULE_DIR}/${ENV_NAME}-py${PY}.lua"
+	if [ "${ENVIRONMENT_MODULE_TYPE}" == "lmod" ]; then
+		MODULE_FILE="${MODULE_DIR}/${ENV_NAME}-py${PY}.lua"
+	elif [ "${ENVIRONMENT_MODULE_TYPE}" == "tcl" ]; then
+                MODULE_FILE="${MODULE_DIR}/${ENV_NAME}-py${PY}"
+	fi
 	echo "Deleting module file: ${MODULE_FILE//$HOME/\$HOME}"
 	rm -f "${MODULE_FILE}"
 
@@ -268,7 +272,11 @@ function create_module()
 		exit 1
 	fi
 
-	MODULE_FILE="${MODULE_DIR}/${ENV_NAME}-py${PY}.lua"
+	if [ "${ENVIRONMENT_MODULE_TYPE}" == "lmod" ]; then
+		MODULE_FILE="${MODULE_DIR}/${ENV_NAME}-py${PY}.lua"
+	elif [ "${ENVIRONMENT_MODULE_TYPE}" == "tcl" ]; then
+                MODULE_FILE="${MODULE_DIR}/${ENV_NAME}-py${PY}"
+	fi
 	CONDA_MODULE=$(module --redirect --terse list ${BASE_CONDA_MODULE_NAME} | grep "^${BASE_CONDA_MODULE_NAME}\/.*")
 
 	source ${MODULE_TEMPLATE} > ${MODULE_FILE}

--- a/conda-env-mod
+++ b/conda-env-mod
@@ -71,6 +71,7 @@ function usage()
                                          Default is '${MODULE_APP_DEF}'.	
            -b|--base-python            : use the Python from base Anaconda module (rarely needed)
            -m|--moduledir MODULE_DIR   : location of module file.
+           -t|--module-template MODULE_TEMPLATE : use a custom module template to generate the module file.
            -j|--jupyter                : generate a Jupyter kernel for this 
                                          environment (implies '--local-py').
            --local-py|--local-python
@@ -513,7 +514,7 @@ fi
 # Parse command line
 SUBCOMMAND="$1"
 shift
-TEMP=$(getopt -o a:hp:m:n:yjb --long appname:,help,prefix:,moduledir:,name:,yes,jupyter,local-py,local-python,add-path,add-to-path,base-python -- "$@")
+TEMP=$(getopt -o a:hp:m:n:yjbt: --long appname:,help,prefix:,moduledir:,name:,yes,jupyter,local-py,local-python,add-path,add-to-path,base-python,module-template: -- "$@")
 eval set -- "$TEMP"
 while true; do
 	case "$1" in
@@ -522,15 +523,17 @@ while true; do
 		-n|--name)
 			ENV_NAME="$2"; shift 2 ;;
 		-p|--prefix)
-			ENV_PREFIX="$2" ; shift 2 ;;
+			ENV_PREFIX="$2"; shift 2 ;;
 		-m|--moduledir)
-			MODULE_TOP="$2" ; shift 2 ;;
+			MODULE_TOP="$2"; shift 2 ;;
 		-y|--yes)
 			Opt_YES=1; shift ;;
 		-j|--jupyter)
 			Opt_JUPYTER=1; shift ;;
 		-b|--base-python)
 			Opt_LOCAL_PY=0; shift ;;
+		-t|--module-template)
+			MODULE_TEMPLATE="$2"; shift 2 ;;
 		--local-py|--local-python|--add-path|--add-to-path)
 			Opt_LOCAL_PY=1; shift ;;
 		--) shift ; break ;;

--- a/templates/rcac/modules/lmod/default.sh
+++ b/templates/rcac/modules/lmod/default.sh
@@ -34,22 +34,13 @@ cat <<-EOF
 	local modroot = "${ENV_DIR}"
 	local pyver   = "${PY}"
 
-	local bashStr = 'eval '..modroot..'/bin/pip "\$@"'
-	local cshStr  = "eval "..modroot.."/bin/pip \$*"
-	set_shell_function("pip",bashStr,cshStr)
-	-- If this is Python3 environment, brace against 'pip3', too
-	if (string.match(pyver,"^3%.")) then
-	    set_shell_function("pip3",bashStr,cshStr)
-	end
-
 	pushenv("CONDA_PREFIX",modroot)
 	pushenv("CONDA_DEFAULT_ENV",modroot)
 	prepend_path("LD_LIBRARY_PATH",modroot.."/lib")
 	prepend_path("PYTHONPATH",modroot.."/lib/python${PY_S}/site-packages")
 	pushenv("PYTHONNOUSERSITE","1")
-EOF
 
-echo ""
+EOF
 
 if [[ $Opt_LOCAL_PY -eq 0 ]]; then
 	# if user put down base-python, then use Python from base Anaconda
@@ -57,11 +48,21 @@ if [[ $Opt_LOCAL_PY -eq 0 ]]; then
 		-- This line is deliberately commented out.
 		-- We want to use Python from base Anaconda.
 		-- prepend_path("PATH",modroot.."/bin")
+
+		local bashStr = 'eval '..modroot..'/bin/pip "\$@"'
+		local cshStr  = "eval "..modroot.."/bin/pip \$*"
+		set_shell_function("pip",bashStr,cshStr)
+		-- If this is Python3 environment, brace against 'pip3', too
+		if (string.match(pyver,"^3%.")) then
+		    set_shell_function("pip3",bashStr,cshStr)
+		end
+
 	EOF
 else
 	# python from the environment (python -V) is added to PYTHONPATH by default
 	cat <<-EOF
 		-- Using Python and tools from the environment
 		prepend_path("PATH",modroot.."/bin")
+
 	EOF
 fi

--- a/templates/rcac/modules/lmod/default.sh
+++ b/templates/rcac/modules/lmod/default.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# This script prints an Lmod module file for a Python environment.
+# All the variables and conditional statements are evaluated inside "conda-env-mod"
+# using the "source" function in bash.
+# -----------------------------------------------------------------------------------------
+# Useful varibales defined by "conda-env-mod"
+# ENV_DIR := path to environment
+# $PY := full pyhton version, e.g., 3.10.11
+# $PY_S := short python version, e.g., 3.10
+# Opt_LOCAL_PY := 0|1, 
+#						1 means use python from the environment
+#						0 means use python from base anaconda
+#------------------------------------------------------------------------------------------
+
+cat <<-EOF
+	-- created on $(date) by $USER
+
+EOF
+
+if [ "${CONDA_MODULE}" != "" ]; then
+	cat <<-EOF
+		depends_on("${CONDA_MODULE}")
+	EOF
+elif [ -f "${CONDA_PREFIX}/bin/conda" ]; then
+	cat <<-EOF
+		-- Use the base conda that created this environment.
+		prepend_path("PATH","${CONDA_PREFIX}/bin")
+	EOF
+else
+	echo -e "WARNING: Couldn't find an anaconda module.\nPlease make sure you initialize conda separately." >&2
+fi
+
+cat <<-EOF
+	local modroot = "${ENV_DIR}"
+	local pyver   = "${PY}"
+
+	local bashStr = 'eval '..modroot..'/bin/pip "\$@"'
+	local cshStr  = "eval "..modroot.."/bin/pip \$*"
+	set_shell_function("pip",bashStr,cshStr)
+	-- If this is Python3 environment, brace against 'pip3', too
+	if (string.match(pyver,"^3%.")) then
+	    set_shell_function("pip3",bashStr,cshStr)
+	end
+
+	pushenv("CONDA_PREFIX",modroot)
+	pushenv("CONDA_DEFAULT_ENV",modroot)
+	prepend_path("LD_LIBRARY_PATH",modroot.."/lib")
+	prepend_path("PYTHONPATH",modroot.."/lib/python${PY_S}/site-packages")
+	pushenv("PYTHONNOUSERSITE","1")
+EOF
+
+echo ""
+
+if [[ $Opt_LOCAL_PY -eq 0 ]]; then
+	# if user put down base-python, then use Python from base Anaconda
+	cat <<-EOF
+		-- This line is deliberately commented out.
+		-- We want to use Python from base Anaconda.
+		-- prepend_path("PATH",modroot.."/bin")
+	EOF
+else
+	# python from the environment (python -V) is added to PYTHONPATH by default
+	cat <<-EOF
+		-- Using Python and tools from the environment
+		prepend_path("PATH",modroot.."/bin")
+	EOF
+fi

--- a/templates/rcac/modules/tcl/default.sh
+++ b/templates/rcac/modules/tcl/default.sh
@@ -35,20 +35,13 @@ cat <<-EOF
 	set modroot "${ENV_DIR}"
 	set pyver "${PY}"
 
-	set-alias pip "\$modroot/bin/pip"
-	# If this is Python3 environment, brace against 'pip3', too
-	if {[regexp "^3\." "$pyver" match]} {
-	    set-alias pip3 "\$modroot/bin/pip"
-	}
-
 	pushenv CONDA_PREFIX "\$modroot"
 	pushenv CONDA_DEFAULT_ENV "\$modroot"
 	prepend-path LD_LIBRARY_PATH "\$modroot/lib"
 	prepend-path PYTHONPATH "\$modroot/lib/python${PY_S}/site-packages"
 	pushenv PYTHONNOUSERSITE "1"
-EOF
 
-echo ""
+EOF
 
 if [[ $Opt_LOCAL_PY -eq 0 ]]; then
 	# if user put down base-python, then use Python from base Anaconda
@@ -56,6 +49,13 @@ if [[ $Opt_LOCAL_PY -eq 0 ]]; then
 		# This line is deliberately commented out.
 		# We want to use Python from base Anaconda.
 		# prepend-path PATH "\$modroot/bin"
+
+		set-alias pip "\$modroot/bin/pip"
+		# If this is Python3 environment, brace against 'pip3', too
+		if {[regexp "^3\." "$pyver" match]} {
+		    set-alias pip3 "\$modroot/bin/pip"
+		}
+
 	EOF
 else
 	# python from the environment (python -V) is added to PYTHONPATH by default

--- a/templates/rcac/modules/tcl/default.sh
+++ b/templates/rcac/modules/tcl/default.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# This script prints a TCL module file for a Python environment.
+# All the variables and conditional statements are evaluated inside "conda-env-mod"
+# using the "source" function in bash.
+# -----------------------------------------------------------------------------------------
+# Useful varibales defined by "conda-env-mod"
+# ENV_DIR := path to environment
+# $PY := full pyhton version, e.g., 3.10.11
+# $PY_S := short python version, e.g., 3.10
+# Opt_LOCAL_PY := 0|1, 
+#						1 means use python from the environment
+#						0 means use python from base anaconda
+#------------------------------------------------------------------------------------------
+
+cat <<-EOF
+	#%Module
+	# created on $(date) by $USER
+
+EOF
+
+if [ "${CONDA_MODULE}" != "" ]; then
+	cat <<-EOF
+		module load "${CONDA_MODULE}"
+	EOF
+elif [ -f "${CONDA_PREFIX}/bin/conda" ]; then
+	cat <<-EOF
+		# Use the base conda that created this environment.
+		prepend-path PATH "${CONDA_PREFIX}/bin"
+	EOF
+else
+	echo -e "WARNING: Couldn't find an anaconda module.\nPlease make sure you initialize conda separately." >&2
+fi
+
+cat <<-EOF
+	set modroot "${ENV_DIR}"
+	set pyver "${PY}"
+
+	set-alias pip "\$modroot/bin/pip"
+	# If this is Python3 environment, brace against 'pip3', too
+	if {[regexp "^3\." "$pyver" match]} {
+	    set-alias pip3 "\$modroot/bin/pip"
+	}
+
+	pushenv CONDA_PREFIX "\$modroot"
+	pushenv CONDA_DEFAULT_ENV "\$modroot"
+	prepend-path LD_LIBRARY_PATH "\$modroot/lib"
+	prepend-path PYTHONPATH "\$modroot/lib/python${PY_S}/site-packages"
+	pushenv PYTHONNOUSERSITE "1"
+EOF
+
+echo ""
+
+if [[ $Opt_LOCAL_PY -eq 0 ]]; then
+	# if user put down base-python, then use Python from base Anaconda
+	cat <<-EOF
+		# This line is deliberately commented out.
+		# We want to use Python from base Anaconda.
+		# prepend-path PATH "\$modroot/bin"
+	EOF
+else
+	# python from the environment (python -V) is added to PYTHONPATH by default
+	cat <<-EOF
+		# Using Python and tools from the environment
+		prepend-path PATH "\$modroot/bin"
+	EOF
+fi


### PR DESCRIPTION
This PR allows users to use a custom module file template with `conda-env-mod`. Primary changes are:
1. Move module file generation code into a separate "template" file. A template in this case is simply a bash script that generates Lua or TCL code for a module file. Default templates are located in `templates/rcac/modules/{lmod|tcl}/default.sh`. Sites can define their own templates by changing `$DEFAULT_TEMPLATE_DIR` in the config section.
2. Enable a user to specify a custom template in command line. This adds the new command line option: `-t|--module-template MODULE_TEMPLATE`. Note that the `MODULE_TEMPLATE` must be a fully qualified path to a bash script.
3. Adds a basic TCL module template.